### PR TITLE
Add T2 metrics charts

### DIFF
--- a/src/app/components/charts/congestionWindowChart/CongestionWindowChart.tsx
+++ b/src/app/components/charts/congestionWindowChart/CongestionWindowChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { LineChart } from '@mui/x-charts'
+import { loadCongestionWindow } from './loadCongestionWindowChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const CongestionWindowChart = () => {
+  const [data, setData] = useState<{ time: number; cwnd: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadCongestionWindow(values.url_stats_completo)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_completo])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <LineChart
+      dataset={data}
+      xAxis={[{ dataKey: 'time', label: 'Tempo (s)' }]}
+      series={[{ dataKey: 'cwnd', label: 'Janela' }]}
+      height={250}
+    />
+  )
+}
+
+export default CongestionWindowChart

--- a/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.code.ts
+++ b/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.code.ts
@@ -1,0 +1,17 @@
+export const code = `
+export async function loadCongestionWindow(url: string): Promise<Array<{ time: number; cwnd: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const cw = data.janela_congestionamento || {}
+    const firstKey = Object.keys(cw)[0]
+    if (!firstKey) return []
+    const arr: [number, number][] = cw[firstKey]
+    return arr.map(([t, v]) => ({ time: Number(t), cwnd: Number(v) }))
+  } catch (e) {
+    console.error('Erro ao carregar janela de congestionamento:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.ts
+++ b/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.ts
@@ -1,0 +1,15 @@
+export async function loadCongestionWindow(url: string): Promise<Array<{ time: number; cwnd: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const cw = data.janela_congestionamento || {}
+    const firstKey = Object.keys(cw)[0]
+    if (!firstKey) return []
+    const arr: [number, number][] = cw[firstKey]
+    return arr.map(([t, v]) => ({ time: Number(t), cwnd: Number(v) }))
+  } catch (e) {
+    console.error('Erro ao carregar janela de congestionamento:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/connectionDurationChart/ConnectionDurationChart.tsx
+++ b/src/app/components/charts/connectionDurationChart/ConnectionDurationChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadConnectionDurations } from './loadConnectionDurationChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const ConnectionDurationChart = () => {
+  const [data, setData] = useState<{ id: string; duration: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadConnectionDurations(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'id', label: 'Conexão', scaleType: 'band' }]}
+      series={[{ dataKey: 'duration', label: 'Duração (s)' }]}
+      height={250}
+    />
+  )
+}
+
+export default ConnectionDurationChart

--- a/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.code.ts
+++ b/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.code.ts
@@ -1,0 +1,16 @@
+export const code = `
+import { MainValues } from '@/app/contexts/MainValuesContext'
+
+export async function loadConnectionDurations(url: string): Promise<Array<{ id: string; duration: number }>> {
+  try {
+    const response = await fetch(url, { cache: "no-store" })
+    if (!response.ok) throw new Error("Erro ao carregar o JSON")
+    const data = await response.json()
+    const map: Record<string, number> = data.duracao_conexoes || {}
+    return Object.entries(map).map(([id, duration]) => ({ id, duration: Number(duration) }))
+  } catch (error) {
+    console.error("Erro ao carregar duração das conexões:", error)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.ts
+++ b/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.ts
@@ -1,0 +1,14 @@
+import { MainValues } from "@/app/contexts/MainValuesContext"
+
+export async function loadConnectionDurations(url: string): Promise<Array<{ id: string; duration: number }>> {
+  try {
+    const response = await fetch(url, { cache: "no-store" })
+    if (!response.ok) throw new Error("Erro ao carregar o JSON")
+    const data = await response.json()
+    const map: Record<string, number> = data.duracao_conexoes || {}
+    return Object.entries(map).map(([id, duration]) => ({ id, duration: Number(duration) }))
+  } catch (error) {
+    console.error("Erro ao carregar duração das conexões:", error)
+    return []
+  }
+}

--- a/src/app/components/charts/elephantFlowsChart/ElephantFlowsChart.tsx
+++ b/src/app/components/charts/elephantFlowsChart/ElephantFlowsChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadElephantFlows } from './loadElephantFlowsChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const ElephantFlowsChart = () => {
+  const [data, setData] = useState<{ id: string; bytes: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadElephantFlows(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'id', label: 'Conexão', scaleType: 'band' }]}
+      series={[{ dataKey: 'bytes', label: 'Bytes' }]}
+      height={250}
+    />
+  )
+}
+
+export default ElephantFlowsChart

--- a/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.code.ts
+++ b/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadElephantFlows(url: string): Promise<Array<{ id: string; bytes: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.fluxos_elefantes || {}
+    return Object.entries(map).map(([id, bytes]) => ({ id, bytes: Number(bytes) }))
+  } catch (e) {
+    console.error('Erro ao carregar fluxos elefantes:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.ts
+++ b/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.ts
@@ -1,0 +1,12 @@
+export async function loadElephantFlows(url: string): Promise<Array<{ id: string; bytes: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.fluxos_elefantes || {}
+    return Object.entries(map).map(([id, bytes]) => ({ id, bytes: Number(bytes) }))
+  } catch (e) {
+    console.error('Erro ao carregar fluxos elefantes:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/handshakeTimeChart/HandshakeTimeChart.tsx
+++ b/src/app/components/charts/handshakeTimeChart/HandshakeTimeChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadHandshakeTimes } from './loadHandshakeTimeChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const HandshakeTimeChart = () => {
+  const [data, setData] = useState<{ idx: number; time: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadHandshakeTimes(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'idx', label: 'Conexão', scaleType: 'band' }]}
+      series={[{ dataKey: 'time', label: 'Tempo (s)' }]}
+      height={250}
+    />
+  )
+}
+
+export default HandshakeTimeChart

--- a/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.code.ts
+++ b/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadHandshakeTimes(url: string): Promise<Array<{ idx: number; time: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const arr: number[] = data.tempos_estabelecimento || []
+    return arr.map((t, i) => ({ idx: i + 1, time: Number(t) }))
+  } catch (e) {
+    console.error('Erro ao carregar tempos de handshake:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.ts
+++ b/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.ts
@@ -1,0 +1,12 @@
+export async function loadHandshakeTimes(url: string): Promise<Array<{ idx: number; time: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const arr: number[] = data.tempos_estabelecimento || []
+    return arr.map((t, i) => ({ idx: i + 1, time: Number(t) }))
+  } catch (e) {
+    console.error('Erro ao carregar tempos de handshake:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/microburstsChart/MicroburstsChart.tsx
+++ b/src/app/components/charts/microburstsChart/MicroburstsChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { LineChart } from '@mui/x-charts'
+import { loadMicrobursts } from './loadMicroburstsChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const MicroburstsChart = () => {
+  const [data, setData] = useState<{ time: number; packets: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadMicrobursts(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <LineChart
+      dataset={data}
+      xAxis={[{ dataKey: 'time', label: 'Tempo (s)' }]}
+      series={[{ dataKey: 'packets', label: 'Pacotes' }]}
+      height={250}
+    />
+  )
+}
+
+export default MicroburstsChart

--- a/src/app/components/charts/microburstsChart/loadMicroburstsChart.code.ts
+++ b/src/app/components/charts/microburstsChart/loadMicroburstsChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadMicrobursts(url: string): Promise<Array<{ time: number; packets: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.microbursts || {}
+    return Object.entries(map).map(([t, p]) => ({ time: Number(t), packets: Number(p) }))
+  } catch (e) {
+    console.error('Erro ao carregar microbursts:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/microburstsChart/loadMicroburstsChart.ts
+++ b/src/app/components/charts/microburstsChart/loadMicroburstsChart.ts
@@ -1,0 +1,12 @@
+export async function loadMicrobursts(url: string): Promise<Array<{ time: number; packets: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.microbursts || {}
+    return Object.entries(map).map(([t, p]) => ({ time: Number(t), packets: Number(p) }))
+  } catch (e) {
+    console.error('Erro ao carregar microbursts:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/mssChart/MssChart.tsx
+++ b/src/app/components/charts/mssChart/MssChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadMssPerConnection } from './loadMssChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const MssChart = () => {
+  const [data, setData] = useState<{ id: string; mss: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadMssPerConnection(values.url_stats_completo)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_completo])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'id', label: 'Conexão', scaleType: 'band' }]}
+      series={[{ dataKey: 'mss', label: 'MSS' }]}
+      height={250}
+    />
+  )
+}
+
+export default MssChart

--- a/src/app/components/charts/mssChart/loadMssChart.code.ts
+++ b/src/app/components/charts/mssChart/loadMssChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadMssPerConnection(url: string): Promise<Array<{ id: string; mss: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.mss_por_conexao || {}
+    return Object.entries(map).map(([id, mss]) => ({ id, mss: Number(mss) }))
+  } catch (e) {
+    console.error('Erro ao carregar MSS:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/mssChart/loadMssChart.ts
+++ b/src/app/components/charts/mssChart/loadMssChart.ts
@@ -1,0 +1,12 @@
+export async function loadMssPerConnection(url: string): Promise<Array<{ id: string; mss: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.mss_por_conexao || {}
+    return Object.entries(map).map(([id, mss]) => ({ id, mss: Number(mss) }))
+  } catch (e) {
+    console.error('Erro ao carregar MSS:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/retransmissionsChart/RetransmissionsChart.tsx
+++ b/src/app/components/charts/retransmissionsChart/RetransmissionsChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadRetransmissions } from './loadRetransmissionsChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const RetransmissionsChart = () => {
+  const [data, setData] = useState<{ ip: string; count: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadRetransmissions(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'ip', label: 'IP', scaleType: 'band' }]}
+      series={[{ dataKey: 'count', label: 'Retransmissões' }]}
+      height={250}
+    />
+  )
+}
+
+export default RetransmissionsChart

--- a/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.code.ts
+++ b/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadRetransmissions(url: string): Promise<Array<{ ip: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.taxa_retransmissoes || {}
+    return Object.entries(map).map(([ip, count]) => ({ ip, count: Number(count) }))
+  } catch (e) {
+    console.error('Erro ao carregar retransmissões:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.ts
+++ b/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.ts
@@ -1,0 +1,12 @@
+export async function loadRetransmissions(url: string): Promise<Array<{ ip: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.taxa_retransmissoes || {}
+    return Object.entries(map).map(([ip, count]) => ({ ip, count: Number(count) }))
+  } catch (e) {
+    console.error('Erro ao carregar retransmissões:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/rttChart/RttChart.tsx
+++ b/src/app/components/charts/rttChart/RttChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadRttPerConnection } from './loadRttChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const RttChart = () => {
+  const [data, setData] = useState<{ id: string; rtt: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadRttPerConnection(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'id', label: 'Conexão', scaleType: 'band' }]}
+      series={[{ dataKey: 'rtt', label: 'RTT (s)' }]}
+      height={250}
+    />
+  )
+}
+
+export default RttChart

--- a/src/app/components/charts/rttChart/loadRttChart.code.ts
+++ b/src/app/components/charts/rttChart/loadRttChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadRttPerConnection(url: string): Promise<Array<{ id: string; rtt: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.rtt_por_conexao || {}
+    return Object.entries(map).map(([id, rtt]) => ({ id, rtt: Number(rtt) }))
+  } catch (e) {
+    console.error('Erro ao carregar RTT:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/rttChart/loadRttChart.ts
+++ b/src/app/components/charts/rttChart/loadRttChart.ts
@@ -1,0 +1,12 @@
+export async function loadRttPerConnection(url: string): Promise<Array<{ id: string; rtt: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.rtt_por_conexao || {}
+    return Object.entries(map).map(([id, rtt]) => ({ id, rtt: Number(rtt) }))
+  } catch (e) {
+    console.error('Erro ao carregar RTT:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/segmentSizeChart/SegmentSizeChart.tsx
+++ b/src/app/components/charts/segmentSizeChart/SegmentSizeChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadSegmentSizeDistribution } from './loadSegmentSizeChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const SegmentSizeChart = () => {
+  const [data, setData] = useState<{ size: number; count: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadSegmentSizeDistribution(values.url_stats_completo)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_completo])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'size', label: 'Tamanho (bytes)', scaleType: 'band' }]}
+      series={[{ dataKey: 'count', label: 'Quantidade' }]}
+      height={250}
+    />
+  )
+}
+
+export default SegmentSizeChart

--- a/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.code.ts
+++ b/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.code.ts
@@ -1,0 +1,19 @@
+export const code = `
+export async function loadSegmentSizeDistribution(url: string): Promise<Array<{ size: number; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const arr: number[] = data.tamanhos_segmentos || []
+    const map: Record<number, number> = {}
+    for (const s of arr) {
+      const v = Number(s)
+      map[v] = (map[v] || 0) + 1
+    }
+    return Object.entries(map).map(([size, count]) => ({ size: Number(size), count }))
+  } catch (e) {
+    console.error('Erro ao carregar distribuição de tamanhos:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.ts
+++ b/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.ts
@@ -1,0 +1,17 @@
+export async function loadSegmentSizeDistribution(url: string): Promise<Array<{ size: number; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const arr: number[] = data.tamanhos_segmentos || []
+    const map: Record<number, number> = {}
+    for (const s of arr) {
+      const v = Number(s)
+      map[v] = (map[v] || 0) + 1
+    }
+    return Object.entries(map).map(([size, count]) => ({ size: Number(size), count }))
+  } catch (e) {
+    console.error('Erro ao carregar distribuição de tamanhos:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/throughputChart/ThroughputChart.tsx
+++ b/src/app/components/charts/throughputChart/ThroughputChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadThroughput } from './loadThroughputChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const ThroughputChart = () => {
+  const [data, setData] = useState<{ id: string; value: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadThroughput(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'id', label: 'Conexão', scaleType: 'band' }]}
+      series={[{ dataKey: 'value', label: 'Bytes/s' }]}
+      height={250}
+    />
+  )
+}
+
+export default ThroughputChart

--- a/src/app/components/charts/throughputChart/loadThroughputChart.code.ts
+++ b/src/app/components/charts/throughputChart/loadThroughputChart.code.ts
@@ -1,0 +1,14 @@
+export const code = `
+export async function loadThroughput(url: string): Promise<Array<{ id: string; value: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.throughput_por_conexao || {}
+    return Object.entries(map).map(([id, value]) => ({ id, value: Number(value) }))
+  } catch (e) {
+    console.error('Erro ao carregar throughput:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/throughputChart/loadThroughputChart.ts
+++ b/src/app/components/charts/throughputChart/loadThroughputChart.ts
@@ -1,0 +1,12 @@
+export async function loadThroughput(url: string): Promise<Array<{ id: string; value: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.throughput_por_conexao || {}
+    return Object.entries(map).map(([id, value]) => ({ id, value: Number(value) }))
+  } catch (e) {
+    console.error('Erro ao carregar throughput:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/topApplicationsChart/TopApplicationsChart.tsx
+++ b/src/app/components/charts/topApplicationsChart/TopApplicationsChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadTopApplications } from './loadTopApplicationsChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const TopApplicationsChart = () => {
+  const [data, setData] = useState<{ port: string; count: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadTopApplications(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'port', label: 'Porta', scaleType: 'band' }]}
+      series={[{ dataKey: 'count', label: 'Pacotes' }]}
+      height={250}
+    />
+  )
+}
+
+export default TopApplicationsChart

--- a/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.code.ts
+++ b/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.code.ts
@@ -1,0 +1,15 @@
+export const code = `
+export async function loadTopApplications(url: string): Promise<Array<{ port: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.top_aplicacoes_portas || {}
+    const entries = Object.entries(map).map(([port, count]) => ({ port, count: Number(count) }))
+    return entries.sort((a, b) => b.count - a.count).slice(0, 10)
+  } catch (e) {
+    console.error('Erro ao carregar top aplicações:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.ts
+++ b/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.ts
@@ -1,0 +1,13 @@
+export async function loadTopApplications(url: string): Promise<Array<{ port: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.top_aplicacoes_portas || {}
+    const entries = Object.entries(map).map(([port, count]) => ({ port, count: Number(count) }))
+    return entries.sort((a, b) => b.count - a.count).slice(0, 10)
+  } catch (e) {
+    console.error('Erro ao carregar top aplicações:', e)
+    return []
+  }
+}

--- a/src/app/t2-metricas/AdvancedCharts.tsx
+++ b/src/app/t2-metricas/AdvancedCharts.tsx
@@ -2,108 +2,141 @@
 
 import React, { useState } from 'react'
 
-import TopActiveIPsChart from '../components/charts/topActiveIPsChart/TopActiveIPsChart'
-import IPEntropyChart from '../components/charts/ipEntropyChart/IPEntropyChart'
-import BytesPerIPChart from '../components/charts/bytesPerIPChart/BytesPerIPChart'
-import TrafficOverTimeChart from '../components/charts/trafficOverTimeChart/TrafficOverTimeChart'
-import PacketSizeFrequencyChart from '../components/charts/packetSizeFrequencyChart/PacketSizeFrequencyChart'
-import AnomalyPatternsChart from '../components/charts/anomalyPatternsChart/AnomalyPatternsChart'
-import AvgIPGPerIPChart from '../components/charts/avgIPGPerIPChart/AvgIPGPerIPChart'
+import ConnectionDurationChart from '../components/charts/connectionDurationChart/ConnectionDurationChart'
+import RttChart from '../components/charts/rttChart/RttChart'
+import RetransmissionsChart from '../components/charts/retransmissionsChart/RetransmissionsChart'
+import ThroughputChart from '../components/charts/throughputChart/ThroughputChart'
+import CongestionWindowChart from '../components/charts/congestionWindowChart/CongestionWindowChart'
+import HandshakeTimeChart from '../components/charts/handshakeTimeChart/HandshakeTimeChart'
+import SegmentSizeChart from '../components/charts/segmentSizeChart/SegmentSizeChart'
+import MssChart from '../components/charts/mssChart/MssChart'
+import ElephantFlowsChart from '../components/charts/elephantFlowsChart/ElephantFlowsChart'
+import MicroburstsChart from '../components/charts/microburstsChart/MicroburstsChart'
+import TopApplicationsChart from '../components/charts/topApplicationsChart/TopApplicationsChart'
 
 import ChartContainer from '../components/ChartContainer'
 import ChartAccordion from '../components/ChartAccordion'
 import { ChartBox } from '../components/ChartBox'
 import ChartFunctionDescription from '../components/ChartFunctionDescription'
 
-import { code as loadBytesPerIP } from '../components/charts/bytesPerIPChart/loadBytesPerIPChart.code'
-import { code as loadTrafficOverTime } from '../components/charts/trafficOverTimeChart/loadTrafficOverTimeChart.code'
-import { code as loadPacketSizeFrequency } from '../components/charts/packetSizeFrequencyChart/loadPacketSizeFrequencyChart.code'
-import { code as loadAvgIPGPerIP } from '../components/charts/avgIPGPerIPChart/loadAvgIPGPerIPChart.code'
-import { code as loadTopActiveIPs } from '../components/charts/topActiveIPsChart/loadTopActiveIPsChart.code'
-import { code as loadIPEntropyByWindow } from '../components/charts/ipEntropyChart/loadIpEntropyChart.code'
-import { code as loadAnomalyPatterns } from '../components/charts/anomalyPatternsChart/loadAnomalyPatternsChart.code'
+import { code as loadConnectionDurationCode } from '../components/charts/connectionDurationChart/loadConnectionDurationChart.code'
+import { code as loadRttCode } from '../components/charts/rttChart/loadRttChart.code'
+import { code as loadRetransmissionsCode } from '../components/charts/retransmissionsChart/loadRetransmissionsChart.code'
+import { code as loadThroughputCode } from '../components/charts/throughputChart/loadThroughputChart.code'
+import { code as loadCongestionWindowCode } from '../components/charts/congestionWindowChart/loadCongestionWindowChart.code'
+import { code as loadHandshakeTimeCode } from '../components/charts/handshakeTimeChart/loadHandshakeTimeChart.code'
+import { code as loadSegmentSizeCode } from '../components/charts/segmentSizeChart/loadSegmentSizeChart.code'
+import { code as loadMssCode } from '../components/charts/mssChart/loadMssChart.code'
+import { code as loadElephantFlowsCode } from '../components/charts/elephantFlowsChart/loadElephantFlowsChart.code'
+import { code as loadMicroburstsCode } from '../components/charts/microburstsChart/loadMicroburstsChart.code'
+import { code as loadTopApplicationsCode } from '../components/charts/topApplicationsChart/loadTopApplicationsChart.code'
 
 export const AdvancedCharts = () => {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
-  const handleChange =
-    (key: string) => (_: React.SyntheticEvent, isExpanded: boolean) => {
-      setExpanded(prev => ({ ...prev, [key]: isExpanded }))
-    }
+  const handleChange = (key: string) => (_: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpanded(prev => ({ ...prev, [key]: isExpanded }))
+  }
 
   return (
     <ChartContainer>
-      <ChartBox title="Top 10 IPs Mais Ativos" description="Exibe os IPs que mais enviaram pacotes, útil para identificar os principais emissores de tráfego.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-top-ips']} onChange={handleChange('code-top-ips')}>
-          <ChartFunctionDescription>{loadTopActiveIPs.toString()}</ChartFunctionDescription>
+      <ChartBox title="Duração das Conexões">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-duracao']} onChange={handleChange('code-duracao')}>
+          <ChartFunctionDescription>{loadConnectionDurationCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['top-ips']} onChange={handleChange('top-ips')}>
-          <TopActiveIPsChart />
-        </ChartAccordion>
-      </ChartBox>
-
-      <ChartBox title="IPG Médio e Desvio Padrão por IP" description="Mede a regularidade ou dispersão dos envios de pacotes por IP.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-avg-ipg']} onChange={handleChange('code-avg-ipg')}>
-          <ChartFunctionDescription>{loadAvgIPGPerIP.toString()}</ChartFunctionDescription>
-        </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['avg-ipg']} onChange={handleChange('avg-ipg')}>
-          <AvgIPGPerIPChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['duracao']} onChange={handleChange('duracao')}>
+          <ConnectionDurationChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox title="Entropia da Distribuição de IPs" description="Calcula a aleatoriedade ou previsibilidade dos IPs de origem.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-entropy']} onChange={handleChange('code-entropy')}>
-          <ChartFunctionDescription>{loadIPEntropyByWindow.toString()}</ChartFunctionDescription>
+      <ChartBox title="RTT Estimado por Conexão">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-rtt']} onChange={handleChange('code-rtt')}>
+          <ChartFunctionDescription>{loadRttCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['entropy']} onChange={handleChange('entropy')}>
-          <IPEntropyChart />
-        </ChartAccordion>
-      </ChartBox>
-
-      <ChartBox title="Volume Total de Bytes por IP" description="Quantifica a quantidade de dados transmitidos por cada IP.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-bytes']} onChange={handleChange('code-bytes')}>
-          <ChartFunctionDescription>{loadBytesPerIP.toString()}</ChartFunctionDescription>
-        </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['bytes']} onChange={handleChange('bytes')}>
-          <BytesPerIPChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['rtt']} onChange={handleChange('rtt')}>
+          <RttChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox title="Variação de Tráfego no Tempo" description="Mostra flutuações do tráfego ao longo do tempo em janelas regulares.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-traffic']} onChange={handleChange('code-traffic')}>
-          <ChartFunctionDescription>{loadTrafficOverTime.toString()}</ChartFunctionDescription>
+      <ChartBox title="Número de Retransmissões por IP">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-retrans']} onChange={handleChange('code-retrans')}>
+          <ChartFunctionDescription>{loadRetransmissionsCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['traffic']} onChange={handleChange('traffic')}>
-          <TrafficOverTimeChart />
-        </ChartAccordion>
-      </ChartBox>
-
-      <ChartBox title="Relação entre Tamanho dos Pacotes e Frequência" description="Avalia padrões de envio em função do tamanho dos pacotes.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-packets']} onChange={handleChange('code-packets')}>
-          <ChartFunctionDescription>{loadPacketSizeFrequency.toString()}</ChartFunctionDescription>
-        </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['packets']} onChange={handleChange('packets')}>
-          <PacketSizeFrequencyChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['retrans']} onChange={handleChange('retrans')}>
+          <RetransmissionsChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox title="Padrões Anômalos de Comunicação" description="Destaca comportamentos atípicos, como bursts ou longos períodos sem tráfego.">
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-anomalies']} onChange={handleChange('code-anomalies')}>
-          <ChartFunctionDescription>{loadAnomalyPatterns.toString()}</ChartFunctionDescription>
+      <ChartBox title="Throughput Médio por Conexão">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-throughput']} onChange={handleChange('code-throughput')}>
+          <ChartFunctionDescription>{loadThroughputCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['anomalies']} onChange={handleChange('anomalies')}>
-          <AnomalyPatternsChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['throughput']} onChange={handleChange('throughput')}>
+          <ThroughputChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox title="Mapa de Calor: IPs x Tempo x Volume" description="Representação densa da atividade por IP ao longo do tempo.">
-        Em construção!
-        {/* <ChartAccordion title="Ver Código" expanded={!!expanded['code-heatmap']} onChange={handleChange('code-heatmap')}>
-          <ChartFunctionDescription>{loadTrafficHeatmap.toString()}</ChartFunctionDescription>
+      <ChartBox title="Evolução da Janela de Congestionamento">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-cwnd']} onChange={handleChange('code-cwnd')}>
+          <ChartFunctionDescription>{loadCongestionWindowCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['heatmap']} onChange={handleChange('heatmap')}>
-          <TrafficHeatmap />
-        </ChartAccordion> */}
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['cwnd']} onChange={handleChange('cwnd')}>
+          <CongestionWindowChart />
+        </ChartAccordion>
+      </ChartBox>
+
+      <ChartBox title="Tempo de Handshake">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-handshake']} onChange={handleChange('code-handshake')}>
+          <ChartFunctionDescription>{loadHandshakeTimeCode.toString()}</ChartFunctionDescription>
+        </ChartAccordion>
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['handshake']} onChange={handleChange('handshake')}>
+          <HandshakeTimeChart />
+        </ChartAccordion>
+      </ChartBox>
+
+      <ChartBox title="Distribuição dos Tamanhos dos Segmentos">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-segments']} onChange={handleChange('code-segments')}>
+          <ChartFunctionDescription>{loadSegmentSizeCode.toString()}</ChartFunctionDescription>
+        </ChartAccordion>
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['segments']} onChange={handleChange('segments')}>
+          <SegmentSizeChart />
+        </ChartAccordion>
+      </ChartBox>
+
+      <ChartBox title="MSS por Conexão">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-mss']} onChange={handleChange('code-mss')}>
+          <ChartFunctionDescription>{loadMssCode.toString()}</ChartFunctionDescription>
+        </ChartAccordion>
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['mss']} onChange={handleChange('mss')}>
+          <MssChart />
+        </ChartAccordion>
+      </ChartBox>
+
+      <ChartBox title="Fluxos Elefantes">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-elephants']} onChange={handleChange('code-elephants')}>
+          <ChartFunctionDescription>{loadElephantFlowsCode.toString()}</ChartFunctionDescription>
+        </ChartAccordion>
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['elephants']} onChange={handleChange('elephants')}>
+          <ElephantFlowsChart />
+        </ChartAccordion>
+      </ChartBox>
+
+      <ChartBox title="Microbursts">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-micro']} onChange={handleChange('code-micro')}>
+          <ChartFunctionDescription>{loadMicroburstsCode.toString()}</ChartFunctionDescription>
+        </ChartAccordion>
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['micro']} onChange={handleChange('micro')}>
+          <MicroburstsChart />
+        </ChartAccordion>
+      </ChartBox>
+
+      <ChartBox title="Top Aplicações por Porta">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-apps']} onChange={handleChange('code-apps')}>
+          <ChartFunctionDescription>{loadTopApplicationsCode.toString()}</ChartFunctionDescription>
+        </ChartAccordion>
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['apps']} onChange={handleChange('apps')}>
+          <TopApplicationsChart />
+        </ChartAccordion>
       </ChartBox>
     </ChartContainer>
   )


### PR DESCRIPTION
## Summary
- implement new charts for connection duration, RTT, retransmissions, throughput, congestion window, handshake time, segment size distribution, MSS, elephant flows, microbursts and popular ports
- fetch metrics from `stats_metricas.json` and `stats_completo.json`
- update `t2-metricas` page to display new metrics

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f25f969883288bd380c03fa7aeb4