### PR TITLE
Add new advanced charts for T2 graficos

### DIFF
--- a/src/app/components/charts/connectionLengthChart/ConnectionLengthChart.tsx
+++ b/src/app/components/charts/connectionLengthChart/ConnectionLengthChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadConnectionLengthComparison } from './loadConnectionLengthChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const ConnectionLengthChart = () => {
+  const [data, setData] = useState<{ type: string; count: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadConnectionLengthComparison(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'type', scaleType: 'band', label: 'Tipo' }]}
+      series={[{ dataKey: 'count', label: 'Conexões' }]}
+      height={250}
+    />
+  )
+}
+
+export default ConnectionLengthChart

--- a/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.code.ts
+++ b/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.code.ts
@@ -1,0 +1,22 @@
+export const code = `
+export async function loadConnectionLengthComparison(url: string, threshold = 10): Promise<Array<{ type: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.duracao_conexoes || {}
+    let short = 0
+    let long = 0
+    Object.values(map).forEach(v => {
+      Number(v) <= threshold ? short++ : long++
+    })
+    return [
+      { type: 'Curtas', count: short },
+      { type: 'Longas', count: long }
+    ]
+  } catch (e) {
+    console.error('Erro ao carregar duracao de conexoes:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.ts
+++ b/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.ts
@@ -1,0 +1,20 @@
+export async function loadConnectionLengthComparison(url: string, threshold = 10): Promise<Array<{ type: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.duracao_conexoes || {}
+    let short = 0
+    let long = 0
+    Object.values(map).forEach(v => {
+      Number(v) <= threshold ? short++ : long++
+    })
+    return [
+      { type: 'Curtas', count: short },
+      { type: 'Longas', count: long }
+    ]
+  } catch (e) {
+    console.error('Erro ao carregar duracao de conexoes:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/handshakeCdfChart/HandshakeCdfChart.tsx
+++ b/src/app/components/charts/handshakeCdfChart/HandshakeCdfChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { LineChart } from '@mui/x-charts'
+import { loadHandshakeCdf } from './loadHandshakeCdfChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const HandshakeCdfChart = () => {
+  const [data, setData] = useState<{ time: number; cdf: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadHandshakeCdf(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <LineChart
+      dataset={data}
+      xAxis={[{ dataKey: 'time', label: 'Tempo (s)' }]}
+      series={[{ dataKey: 'cdf', label: 'CDF' }]}
+      height={250}
+    />
+  )
+}
+
+export default HandshakeCdfChart

--- a/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.code.ts
+++ b/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.code.ts
@@ -1,0 +1,16 @@
+export const code = `
+export async function loadHandshakeCdf(url: string): Promise<Array<{ time: number; cdf: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const arr: number[] = data.tempos_estabelecimento || []
+    const times = arr.map(Number).sort((a, b) => a - b)
+    const total = times.length
+    return times.map((time, i) => ({ time, cdf: parseFloat(((i + 1) / total).toFixed(4)) }))
+  } catch (e) {
+    console.error('Erro ao carregar tempos de handshake:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.ts
+++ b/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.ts
@@ -1,0 +1,14 @@
+export async function loadHandshakeCdf(url: string): Promise<Array<{ time: number; cdf: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const arr: number[] = data.tempos_estabelecimento || []
+    const times = arr.map(Number).sort((a, b) => a - b)
+    const total = times.length
+    return times.map((time, i) => ({ time, cdf: parseFloat(((i + 1) / total).toFixed(4)) }))
+  } catch (e) {
+    console.error('Erro ao carregar tempos de handshake:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/retransmissionRateHistogram/RateHistogramChart.tsx
+++ b/src/app/components/charts/retransmissionRateHistogram/RateHistogramChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { BarChart } from '@mui/x-charts'
+import { loadRetransmissionRateHistogram } from './loadRetransmissionRateHistogram'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const RateHistogramChart = () => {
+  const [data, setData] = useState<{ bin: string; count: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadRetransmissionRateHistogram(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <BarChart
+      dataset={data}
+      xAxis={[{ dataKey: 'bin', scaleType: 'band', label: 'Taxa' }]}
+      series={[{ dataKey: 'count', label: 'Conexões' }]}
+      height={250}
+    />
+  )
+}
+
+export default RateHistogramChart

--- a/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.code.ts
+++ b/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.code.ts
@@ -1,0 +1,29 @@
+export const code = `
+export async function loadRetransmissionRateHistogram(url: string): Promise<Array<{ bin: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.taxa_retransmissoes || {}
+    const values = Object.values(map).map(Number)
+    if (values.length === 0) return []
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const bins = 5
+    const width = (max - min) / bins || 1
+    const counts = Array(bins).fill(0)
+    values.forEach(v => {
+      const idx = Math.min(bins - 1, Math.floor((v - min) / width))
+      counts[idx]++
+    })
+    return counts.map((count, i) => {
+      const start = (min + i * width).toFixed(2)
+      const end = (min + (i + 1) * width).toFixed(2)
+      return { bin: `${start}-${end}`, count }
+    })
+  } catch (e) {
+    console.error('Erro ao carregar taxas de retransmissao:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.ts
+++ b/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.ts
@@ -1,0 +1,27 @@
+export async function loadRetransmissionRateHistogram(url: string): Promise<Array<{ bin: string; count: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map: Record<string, number> = data.taxa_retransmissoes || {}
+    const values = Object.values(map).map(Number)
+    if (values.length === 0) return []
+    const min = Math.min(...values)
+    const max = Math.max(...values)
+    const bins = 5
+    const width = (max - min) / bins || 1
+    const counts = Array(bins).fill(0)
+    values.forEach(v => {
+      const idx = Math.min(bins - 1, Math.floor((v - min) / width))
+      counts[idx]++
+    })
+    return counts.map((count, i) => {
+      const start = (min + i * width).toFixed(2)
+      const end = (min + (i + 1) * width).toFixed(2)
+      return { bin: `${start}-${end}`, count }
+    })
+  } catch (e) {
+    console.error('Erro ao carregar taxas de retransmissao:', e)
+    return []
+  }
+}

--- a/src/app/components/charts/rttScatterChart/RttScatterChart.tsx
+++ b/src/app/components/charts/rttScatterChart/RttScatterChart.tsx
@@ -1,0 +1,33 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { ScatterChart } from '@mui/x-charts'
+import { loadRttScatter } from './loadRttScatterChart'
+import { useMainValues } from '@/app/contexts/MainValuesContext'
+import ChartLoad from '../../ChartLoad'
+
+const RttScatterChart = () => {
+  const [data, setData] = useState<{ idx: number; rtt: number }[]>([])
+  const [loading, setLoading] = useState(true)
+  const { values } = useMainValues()
+
+  useEffect(() => {
+    setLoading(true)
+    loadRttScatter(values.url_stats_metricas)
+      .then(setData)
+      .finally(() => setLoading(false))
+  }, [values.url_stats_metricas])
+
+  if (loading) return <ChartLoad />
+
+  return (
+    <ScatterChart
+      dataset={data}
+      xAxis={[{ dataKey: 'idx', label: 'Conexão' }]}
+      yAxis={[{ dataKey: 'rtt', label: 'RTT (s)' }]}
+      height={250}
+    />
+  )
+}
+
+export default RttScatterChart

--- a/src/app/components/charts/rttScatterChart/loadRttScatterChart.code.ts
+++ b/src/app/components/charts/rttScatterChart/loadRttScatterChart.code.ts
@@ -1,0 +1,17 @@
+export const code = `
+export async function loadRttScatter(url: string): Promise<Array<{ idx: number; rtt: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map = data.rtt_por_conexao || {}
+    const values = Array.isArray(map)
+      ? map.map(([, r]: [string, number]) => Number(r))
+      : Object.values(map).map(Number)
+    return values.map((rtt, i) => ({ idx: i + 1, rtt }))
+  } catch (e) {
+    console.error('Erro ao carregar RTT scatter:', e)
+    return []
+  }
+}
+`

--- a/src/app/components/charts/rttScatterChart/loadRttScatterChart.ts
+++ b/src/app/components/charts/rttScatterChart/loadRttScatterChart.ts
@@ -1,0 +1,15 @@
+export async function loadRttScatter(url: string): Promise<Array<{ idx: number; rtt: number }>> {
+  try {
+    const res = await fetch(url, { cache: 'no-store' })
+    if (!res.ok) throw new Error('Erro ao carregar o JSON')
+    const data = await res.json()
+    const map = data.rtt_por_conexao || {}
+    const values = Array.isArray(map)
+      ? map.map(([, r]: [string, number]) => Number(r))
+      : Object.values(map).map(Number)
+    return values.map((rtt, i) => ({ idx: i + 1, rtt }))
+  } catch (e) {
+    console.error('Erro ao carregar RTT scatter:', e)
+    return []
+  }
+}

--- a/src/app/t2-graficos/NonTrivialCharts.tsx
+++ b/src/app/t2-graficos/NonTrivialCharts.tsx
@@ -2,139 +2,74 @@
 
 import React, { useState } from 'react'
 
-import BurstnessChart from '../components/charts/burstnessChart/BurstnessChart'
-import CDFChart from '../components/charts/cdfChart/CDFChart'
-import HorizontalScanChart from '../components/charts/horizontalScanChart/HorizontalScanChart'
-import IPGChart from '../components/charts/ipgChart/IPGChart'
-import PacketsWindowChart from '../components/charts/packetsWindowChart/PacketWindowChart'
-import StatsChart from '../components/charts/statsChart/StatsChart'
-import TemporalDistChart from '../components/charts/temporalDistChart/TemporalDistChart'
-import AvgPacketSizeChart from '../components/charts/avgPacketSizeChart/AVGPacketSizeChart'
+import CongestionWindowChart from '../components/charts/congestionWindowChart/CongestionWindowChart'
+import RttScatterChart from '../components/charts/rttScatterChart/RttScatterChart'
+import HandshakeCdfChart from '../components/charts/handshakeCdfChart/HandshakeCdfChart'
+import RateHistogramChart from '../components/charts/retransmissionRateHistogram/RateHistogramChart'
+import ConnectionLengthChart from '../components/charts/connectionLengthChart/ConnectionLengthChart'
 
 import ChartContainer from '../components/ChartContainer'
 import ChartAccordion from '../components/ChartAccordion'
 import { ChartBox } from '../components/ChartBox'
 import ChartFunctionDescription from '../components/ChartFunctionDescription'
 
-import { code as loadAndProcessIPGData } from '../components/charts/ipgChart/loadIpgChart.code'
-import { code as loadAvgPacketSizeByIP } from '../components/charts/avgPacketSizeChart/loadAvgPacketSizeChart.code'
-import { code as loadPacketsPerWindow } from '../components/charts/packetsWindowChart/loadPacketsWindowChart.code'
-import { code as loadTemporalDistributionByIP } from '../components/charts/temporalDistChart/loadTemporalDistChart.code'
-import { code as loadBurstnessData } from '../components/charts/burstnessChart/loadBurstnessChart.code'
-import { code as loadPacketSizeCDF } from '../components/charts/cdfChart/loadCdfChart.code'
-import { code as loadIPGStats } from '../components/charts/statsChart/loadStatsChart.code'
-import { code as loadHorizontalScanData } from '../components/charts/horizontalScanChart/loadHorizontalScanChart.code'
+import { code as loadCongestionWindowCode } from '../components/charts/congestionWindowChart/loadCongestionWindowChart.code'
+import { code as loadRttScatterCode } from '../components/charts/rttScatterChart/loadRttScatterChart.code'
+import { code as loadHandshakeCdfCode } from '../components/charts/handshakeCdfChart/loadHandshakeCdfChart.code'
+import { code as loadRetransmissionRateCode } from '../components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.code'
+import { code as loadConnectionLengthCode } from '../components/charts/connectionLengthChart/loadConnectionLengthChart.code'
 
 export const NonTrivialCharts = () => {
   const [expanded, setExpanded] = useState<Record<string, boolean>>({})
 
-  const handleChange = (key: string) => (_: React.SyntheticEvent, isOpen: boolean) => {
-    setExpanded(prev => ({ ...prev, [key]: isOpen }))
+  const handleChange = (key: string) => (_: React.SyntheticEvent, isExpanded: boolean) => {
+    setExpanded(prev => ({ ...prev, [key]: isExpanded }))
   }
 
   return (
     <ChartContainer>
-      <ChartBox
-        fullWidth
-        title="IPG (Inter-Packet Gap)"
-        description="Intervalo de tempo entre pacotes consecutivos, útil para detectar padrões de tráfego e anomalias."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-ipg']} onChange={handleChange('code-ipg')}>
-          <ChartFunctionDescription>{loadAndProcessIPGData.toString()}</ChartFunctionDescription>
+      <ChartBox title="Janela de Congestionamento">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-cwnd']} onChange={handleChange('code-cwnd')}>
+          <ChartFunctionDescription>{loadCongestionWindowCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['ipg']} onChange={handleChange('ipg')}>
-          <IPGChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['cwnd']} onChange={handleChange('cwnd')}>
+          <CongestionWindowChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox
-        fullWidth
-        title="Tamanho Médio por IP"
-        description="Apresenta o tamanho médio dos pacotes enviados por cada endereço IP."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-avg-size']} onChange={handleChange('code-avg-size')}>
-          <ChartFunctionDescription>{loadAvgPacketSizeByIP.toString()}</ChartFunctionDescription>
+      <ChartBox title="RTT por Conexão (Dispersion)">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-rtt']} onChange={handleChange('code-rtt')}>
+          <ChartFunctionDescription>{loadRttScatterCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['avg-size']} onChange={handleChange('avg-size')}>
-          <AvgPacketSizeChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['rtt']} onChange={handleChange('rtt')}>
+          <RttScatterChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox
-        fullWidth
-        title="Distribuição Temporal de Pacotes por IP"
-        description="Evolução do número de pacotes ao longo do tempo, segmentado por IP."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-temporal']} onChange={handleChange('code-temporal')}>
-          <ChartFunctionDescription>{loadTemporalDistributionByIP.toString()}</ChartFunctionDescription>
+      <ChartBox title="CDF do Tempo de Estabelecimento">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-handshake']} onChange={handleChange('code-handshake')}>
+          <ChartFunctionDescription>{loadHandshakeCdfCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['temporal']} onChange={handleChange('temporal')}>
-          <TemporalDistChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['handshake']} onChange={handleChange('handshake')}>
+          <HandshakeCdfChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox
-        fullWidth
-        title="Burstness"
-        description="Visualiza picos de envio de pacotes em curtos períodos de tempo."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-burstness']} onChange={handleChange('code-burstness')}>
-          <ChartFunctionDescription>{loadBurstnessData.toString()}</ChartFunctionDescription>
+      <ChartBox title="Histograma da Taxa de Retransmissões">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-retrans']} onChange={handleChange('code-retrans')}>
+          <ChartFunctionDescription>{loadRetransmissionRateCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['burstness']} onChange={handleChange('burstness')}>
-          <BurstnessChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['retrans']} onChange={handleChange('retrans')}>
+          <RateHistogramChart />
         </ChartAccordion>
       </ChartBox>
 
-      <ChartBox
-        fullWidth
-        title="Pacotes por Janela de Tempo"
-        description="Distribuição de pacotes em janelas de tempo fixas, útil para detectar sobrecarga de tráfego."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-window']} onChange={handleChange('code-window')}>
-          <ChartFunctionDescription>{loadPacketsPerWindow.toString()}</ChartFunctionDescription>
+      <ChartBox title="Conexões Curtas vs Longas">
+        <ChartAccordion title="Ver Código" expanded={!!expanded['code-length']} onChange={handleChange('code-length')}>
+          <ChartFunctionDescription>{loadConnectionLengthCode.toString()}</ChartFunctionDescription>
         </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['window']} onChange={handleChange('window')}>
-          <PacketsWindowChart />
-        </ChartAccordion>
-      </ChartBox>
-
-      <ChartBox
-        fullWidth
-        title="CDF do Tamanho de Pacotes"
-        description="Distribuição acumulada do tamanho dos pacotes, indicando a proporção de pacotes abaixo de um certo tamanho."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-cdf']} onChange={handleChange('code-cdf')}>
-          <ChartFunctionDescription>{loadPacketSizeCDF.toString()}</ChartFunctionDescription>
-        </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['cdf']} onChange={handleChange('cdf')}>
-          <CDFChart />
-        </ChartAccordion>
-      </ChartBox>
-
-      <ChartBox
-        fullWidth
-        title="Skewness e Kurtosis"
-        description="Medidas estatísticas da distribuição do IPG: assimetria e achatamento."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-stats']} onChange={handleChange('code-stats')}>
-          <ChartFunctionDescription>{loadIPGStats.toString()}</ChartFunctionDescription>
-        </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['stats']} onChange={handleChange('stats')}>
-          <StatsChart />
-        </ChartAccordion>
-      </ChartBox>
-
-      <ChartBox
-        fullWidth
-        title="IPs com Destinos Únicos (Scan)"
-        description="Detecta IPs que tentam se comunicar com muitos destinos únicos — possível indício de varredura de rede."
-      >
-        <ChartAccordion title="Ver Código" expanded={!!expanded['code-scan']} onChange={handleChange('code-scan')}>
-          <ChartFunctionDescription>{loadHorizontalScanData.toString()}</ChartFunctionDescription>
-        </ChartAccordion>
-        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['scan']} onChange={handleChange('scan')}>
-          <HorizontalScanChart />
+        <ChartAccordion title="Gerar Gráfico" expanded={!!expanded['length']} onChange={handleChange('length')}>
+          <ConnectionLengthChart />
         </ChartAccordion>
       </ChartBox>
     </ChartContainer>


### PR DESCRIPTION
## Summary
- implement RTT scatter, handshake CDF, retransmission rate histogram and short/long connection charts
- show congestion window, RTT, handshake CDF, retransmission histogram and connection length charts under t2-graficos

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f5fad3108328a4d97b5e893d0143