### PR TITLE
Fix ESLint error in connection length loader

### DIFF
--- a/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.code.ts
+++ b/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.code.ts
@@ -8,7 +8,11 @@ export async function loadConnectionLengthComparison(url: string, threshold = 10
     let short = 0
     let long = 0
     Object.values(map).forEach(v => {
-      Number(v) <= threshold ? short++ : long++
+      if (Number(v) <= threshold) {
+        short++
+      } else {
+        long++
+      }
     })
     return [
       { type: 'Curtas', count: short },

--- a/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.ts
+++ b/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.ts
@@ -6,9 +6,13 @@ export async function loadConnectionLengthComparison(url: string, threshold = 10
     const map: Record<string, number> = data.duracao_conexoes || {}
     let short = 0
     let long = 0
-    Object.values(map).forEach(v => {
-      Number(v) <= threshold ? short++ : long++
-    })
+  Object.values(map).forEach(v => {
+    if (Number(v) <= threshold) {
+      short++
+    } else {
+      long++
+    }
+  })
     return [
       { type: 'Curtas', count: short },
       { type: 'Longas', count: long }


### PR DESCRIPTION
## Summary
- avoid unused expression in `loadConnectionLengthChart`
- keep code sample up to date

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f8a1d7088328abea671c9c9996a3