### PR TITLE
Enable dataset size limits for T2

### DIFF
--- a/src/app/components/charts/congestionWindowChart/CongestionWindowChart.tsx
+++ b/src/app/components/charts/congestionWindowChart/CongestionWindowChart.tsx
@@ -13,10 +13,10 @@ const CongestionWindowChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadCongestionWindow(values.url_stats_completo)
+    loadCongestionWindow(values.url_stats_completo, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_completo])
+  }, [values.url_stats_completo, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.code.ts
+++ b/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.code.ts
@@ -1,5 +1,8 @@
 export const code = `
-export async function loadCongestionWindow(url: string): Promise<Array<{ time: number; cwnd: number }>> {
+export async function loadCongestionWindow(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ time: number; cwnd: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -8,7 +11,9 @@ export async function loadCongestionWindow(url: string): Promise<Array<{ time: n
     const firstKey = Object.keys(cw)[0]
     if (!firstKey) return []
     const arr: [number, number][] = cw[firstKey]
-    return arr.map(([t, v]) => ({ time: Number(t), cwnd: Number(v) }))
+    return arr
+      .slice(0, maxEntries)
+      .map(([t, v]) => ({ time: Number(t), cwnd: Number(v) }))
   } catch (e) {
     console.error('Erro ao carregar janela de congestionamento:', e)
     return []

--- a/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.ts
+++ b/src/app/components/charts/congestionWindowChart/loadCongestionWindowChart.ts
@@ -1,4 +1,7 @@
-export async function loadCongestionWindow(url: string): Promise<Array<{ time: number; cwnd: number }>> {
+export async function loadCongestionWindow(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ time: number; cwnd: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -7,7 +10,9 @@ export async function loadCongestionWindow(url: string): Promise<Array<{ time: n
     const firstKey = Object.keys(cw)[0]
     if (!firstKey) return []
     const arr: [number, number][] = cw[firstKey]
-    return arr.map(([t, v]) => ({ time: Number(t), cwnd: Number(v) }))
+    return arr
+      .slice(0, maxEntries)
+      .map(([t, v]) => ({ time: Number(t), cwnd: Number(v) }))
   } catch (e) {
     console.error('Erro ao carregar janela de congestionamento:', e)
     return []

--- a/src/app/components/charts/connectionDurationChart/ConnectionDurationChart.tsx
+++ b/src/app/components/charts/connectionDurationChart/ConnectionDurationChart.tsx
@@ -13,10 +13,10 @@ const ConnectionDurationChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadConnectionDurations(values.url_stats_metricas)
+    loadConnectionDurations(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.code.ts
+++ b/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.code.ts
@@ -1,13 +1,18 @@
 export const code = `
 import { MainValues } from '@/app/contexts/MainValuesContext'
 
-export async function loadConnectionDurations(url: string): Promise<Array<{ id: string; duration: number }>> {
+export async function loadConnectionDurations(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; duration: number }>> {
   try {
     const response = await fetch(url, { cache: "no-store" })
     if (!response.ok) throw new Error("Erro ao carregar o JSON")
     const data = await response.json()
     const map: Record<string, number> = data.duracao_conexoes || {}
-    return Object.entries(map).map(([id, duration]) => ({ id, duration: Number(duration) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, duration]) => ({ id, duration: Number(duration) }))
   } catch (error) {
     console.error("Erro ao carregar duração das conexões:", error)
     return []

--- a/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.ts
+++ b/src/app/components/charts/connectionDurationChart/loadConnectionDurationChart.ts
@@ -1,10 +1,15 @@
-export async function loadConnectionDurations(url: string): Promise<Array<{ id: string; duration: number }>> {
+export async function loadConnectionDurations(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; duration: number }>> {
   try {
     const response = await fetch(url, { cache: "no-store" })
     if (!response.ok) throw new Error("Erro ao carregar o JSON")
     const data = await response.json()
     const map: Record<string, number> = data.duracao_conexoes || {}
-    return Object.entries(map).map(([id, duration]) => ({ id, duration: Number(duration) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, duration]) => ({ id, duration: Number(duration) }))
   } catch (error) {
     console.error("Erro ao carregar duração das conexões:", error)
     return []

--- a/src/app/components/charts/connectionLengthChart/ConnectionLengthChart.tsx
+++ b/src/app/components/charts/connectionLengthChart/ConnectionLengthChart.tsx
@@ -13,10 +13,10 @@ const ConnectionLengthChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadConnectionLengthComparison(values.url_stats_metricas)
+    loadConnectionLengthComparison(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.code.ts
+++ b/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.code.ts
@@ -1,13 +1,19 @@
 export const code = `
-export async function loadConnectionLengthComparison(url: string, threshold = 10): Promise<Array<{ type: string; count: number }>> {
+export async function loadConnectionLengthComparison(
+  url: string,
+  maxEntries = 10000,
+  threshold = 10
+): Promise<Array<{ type: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.duracao_conexoes || {}
-    let short = 0
-    let long = 0
-    Object.values(map).forEach(v => {
+  let short = 0
+  let long = 0
+  Object.values(map)
+    .slice(0, maxEntries)
+    .forEach(v => {
       if (Number(v) <= threshold) {
         short++
       } else {

--- a/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.ts
+++ b/src/app/components/charts/connectionLengthChart/loadConnectionLengthChart.ts
@@ -1,4 +1,8 @@
-export async function loadConnectionLengthComparison(url: string, threshold = 10): Promise<Array<{ type: string; count: number }>> {
+export async function loadConnectionLengthComparison(
+  url: string,
+  maxEntries = 10000,
+  threshold = 10
+): Promise<Array<{ type: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -6,7 +10,9 @@ export async function loadConnectionLengthComparison(url: string, threshold = 10
     const map: Record<string, number> = data.duracao_conexoes || {}
     let short = 0
     let long = 0
-  Object.values(map).forEach(v => {
+  Object.values(map)
+    .slice(0, maxEntries)
+    .forEach(v => {
     if (Number(v) <= threshold) {
       short++
     } else {

--- a/src/app/components/charts/elephantFlowsChart/ElephantFlowsChart.tsx
+++ b/src/app/components/charts/elephantFlowsChart/ElephantFlowsChart.tsx
@@ -13,10 +13,10 @@ const ElephantFlowsChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadElephantFlows(values.url_stats_metricas)
+    loadElephantFlows(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.code.ts
+++ b/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadElephantFlows(url: string): Promise<Array<{ id: string; bytes: number }>> {
+export async function loadElephantFlows(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; bytes: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.fluxos_elefantes || {}
-    return Object.entries(map).map(([id, bytes]) => ({ id, bytes: Number(bytes) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, bytes]) => ({ id, bytes: Number(bytes) }))
   } catch (e) {
     console.error('Erro ao carregar fluxos elefantes:', e)
     return []

--- a/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.ts
+++ b/src/app/components/charts/elephantFlowsChart/loadElephantFlowsChart.ts
@@ -1,10 +1,15 @@
-export async function loadElephantFlows(url: string): Promise<Array<{ id: string; bytes: number }>> {
+export async function loadElephantFlows(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; bytes: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.fluxos_elefantes || {}
-    return Object.entries(map).map(([id, bytes]) => ({ id, bytes: Number(bytes) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, bytes]) => ({ id, bytes: Number(bytes) }))
   } catch (e) {
     console.error('Erro ao carregar fluxos elefantes:', e)
     return []

--- a/src/app/components/charts/handshakeCdfChart/HandshakeCdfChart.tsx
+++ b/src/app/components/charts/handshakeCdfChart/HandshakeCdfChart.tsx
@@ -13,10 +13,10 @@ const HandshakeCdfChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadHandshakeCdf(values.url_stats_metricas)
+    loadHandshakeCdf(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.code.ts
+++ b/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.code.ts
@@ -1,5 +1,8 @@
 export const code = `
-export async function loadHandshakeCdf(url: string): Promise<Array<{ time: number; cdf: number }>> {
+export async function loadHandshakeCdf(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ time: number; cdf: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -7,7 +10,9 @@ export async function loadHandshakeCdf(url: string): Promise<Array<{ time: numbe
     const arr: number[] = data.tempos_estabelecimento || []
     const times = arr.map(Number).sort((a, b) => a - b)
     const total = times.length
-    return times.map((time, i) => ({ time, cdf: parseFloat(((i + 1) / total).toFixed(4)) }))
+    return times
+      .slice(0, maxEntries)
+      .map((time, i) => ({ time, cdf: parseFloat(((i + 1) / total).toFixed(4)) }))
   } catch (e) {
     console.error('Erro ao carregar tempos de handshake:', e)
     return []

--- a/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.ts
+++ b/src/app/components/charts/handshakeCdfChart/loadHandshakeCdfChart.ts
@@ -1,4 +1,7 @@
-export async function loadHandshakeCdf(url: string): Promise<Array<{ time: number; cdf: number }>> {
+export async function loadHandshakeCdf(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ time: number; cdf: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -6,7 +9,9 @@ export async function loadHandshakeCdf(url: string): Promise<Array<{ time: numbe
     const arr: number[] = data.tempos_estabelecimento || []
     const times = arr.map(Number).sort((a, b) => a - b)
     const total = times.length
-    return times.map((time, i) => ({ time, cdf: parseFloat(((i + 1) / total).toFixed(4)) }))
+    return times
+      .slice(0, maxEntries)
+      .map((time, i) => ({ time, cdf: parseFloat(((i + 1) / total).toFixed(4)) }))
   } catch (e) {
     console.error('Erro ao carregar tempos de handshake:', e)
     return []

--- a/src/app/components/charts/handshakeTimeChart/HandshakeTimeChart.tsx
+++ b/src/app/components/charts/handshakeTimeChart/HandshakeTimeChart.tsx
@@ -13,10 +13,10 @@ const HandshakeTimeChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadHandshakeTimes(values.url_stats_metricas)
+    loadHandshakeTimes(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.code.ts
+++ b/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadHandshakeTimes(url: string): Promise<Array<{ idx: number; time: number }>> {
+export async function loadHandshakeTimes(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ idx: number; time: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const arr: number[] = data.tempos_estabelecimento || []
-    return arr.map((t, i) => ({ idx: i + 1, time: Number(t) }))
+    return arr
+      .slice(0, maxEntries)
+      .map((t, i) => ({ idx: i + 1, time: Number(t) }))
   } catch (e) {
     console.error('Erro ao carregar tempos de handshake:', e)
     return []

--- a/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.ts
+++ b/src/app/components/charts/handshakeTimeChart/loadHandshakeTimeChart.ts
@@ -1,10 +1,15 @@
-export async function loadHandshakeTimes(url: string): Promise<Array<{ idx: number; time: number }>> {
+export async function loadHandshakeTimes(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ idx: number; time: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const arr: number[] = data.tempos_estabelecimento || []
-    return arr.map((t, i) => ({ idx: i + 1, time: Number(t) }))
+    return arr
+      .slice(0, maxEntries)
+      .map((t, i) => ({ idx: i + 1, time: Number(t) }))
   } catch (e) {
     console.error('Erro ao carregar tempos de handshake:', e)
     return []

--- a/src/app/components/charts/microburstsChart/MicroburstsChart.tsx
+++ b/src/app/components/charts/microburstsChart/MicroburstsChart.tsx
@@ -13,10 +13,10 @@ const MicroburstsChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadMicrobursts(values.url_stats_metricas)
+    loadMicrobursts(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/microburstsChart/loadMicroburstsChart.code.ts
+++ b/src/app/components/charts/microburstsChart/loadMicroburstsChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadMicrobursts(url: string): Promise<Array<{ time: number; packets: number }>> {
+export async function loadMicrobursts(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ time: number; packets: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.microbursts || {}
-    return Object.entries(map).map(([t, p]) => ({ time: Number(t), packets: Number(p) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([t, p]) => ({ time: Number(t), packets: Number(p) }))
   } catch (e) {
     console.error('Erro ao carregar microbursts:', e)
     return []

--- a/src/app/components/charts/microburstsChart/loadMicroburstsChart.ts
+++ b/src/app/components/charts/microburstsChart/loadMicroburstsChart.ts
@@ -1,10 +1,15 @@
-export async function loadMicrobursts(url: string): Promise<Array<{ time: number; packets: number }>> {
+export async function loadMicrobursts(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ time: number; packets: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.microbursts || {}
-    return Object.entries(map).map(([t, p]) => ({ time: Number(t), packets: Number(p) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([t, p]) => ({ time: Number(t), packets: Number(p) }))
   } catch (e) {
     console.error('Erro ao carregar microbursts:', e)
     return []

--- a/src/app/components/charts/mssChart/MssChart.tsx
+++ b/src/app/components/charts/mssChart/MssChart.tsx
@@ -13,10 +13,10 @@ const MssChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadMssPerConnection(values.url_stats_completo)
+    loadMssPerConnection(values.url_stats_completo, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_completo])
+  }, [values.url_stats_completo, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/mssChart/loadMssChart.code.ts
+++ b/src/app/components/charts/mssChart/loadMssChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadMssPerConnection(url: string): Promise<Array<{ id: string; mss: number }>> {
+export async function loadMssPerConnection(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; mss: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.mss_por_conexao || {}
-    return Object.entries(map).map(([id, mss]) => ({ id, mss: Number(mss) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, mss]) => ({ id, mss: Number(mss) }))
   } catch (e) {
     console.error('Erro ao carregar MSS:', e)
     return []

--- a/src/app/components/charts/mssChart/loadMssChart.ts
+++ b/src/app/components/charts/mssChart/loadMssChart.ts
@@ -1,10 +1,15 @@
-export async function loadMssPerConnection(url: string): Promise<Array<{ id: string; mss: number }>> {
+export async function loadMssPerConnection(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; mss: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.mss_por_conexao || {}
-    return Object.entries(map).map(([id, mss]) => ({ id, mss: Number(mss) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, mss]) => ({ id, mss: Number(mss) }))
   } catch (e) {
     console.error('Erro ao carregar MSS:', e)
     return []

--- a/src/app/components/charts/retransmissionRateHistogram/RateHistogramChart.tsx
+++ b/src/app/components/charts/retransmissionRateHistogram/RateHistogramChart.tsx
@@ -13,10 +13,10 @@ const RateHistogramChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadRetransmissionRateHistogram(values.url_stats_metricas)
+    loadRetransmissionRateHistogram(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.code.ts
+++ b/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.code.ts
@@ -1,5 +1,8 @@
 export const code = `
-export async function loadRetransmissionRateHistogram(url: string): Promise<Array<{ bin: string; count: number }>> {
+export async function loadRetransmissionRateHistogram(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ bin: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -16,11 +19,13 @@ export async function loadRetransmissionRateHistogram(url: string): Promise<Arra
       const idx = Math.min(bins - 1, Math.floor((v - min) / width))
       counts[idx]++
     })
-    return counts.map((count, i) => {
-      const start = (min + i * width).toFixed(2)
-      const end = (min + (i + 1) * width).toFixed(2)
-      return { bin: $start-$end, count }
-    })
+    return counts
+      .slice(0, maxEntries)
+      .map((count, i) => {
+        const start = (min + i * width).toFixed(2)
+        const end = (min + (i + 1) * width).toFixed(2)
+        return { bin: `${start}-${end}`, count }
+      })
   } catch (e) {
     console.error('Erro ao carregar taxas de retransmissao:', e)
     return []

--- a/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.ts
+++ b/src/app/components/charts/retransmissionRateHistogram/loadRetransmissionRateHistogram.ts
@@ -1,4 +1,7 @@
-export async function loadRetransmissionRateHistogram(url: string): Promise<Array<{ bin: string; count: number }>> {
+export async function loadRetransmissionRateHistogram(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ bin: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -15,11 +18,13 @@ export async function loadRetransmissionRateHistogram(url: string): Promise<Arra
       const idx = Math.min(bins - 1, Math.floor((v - min) / width))
       counts[idx]++
     })
-    return counts.map((count, i) => {
-      const start = (min + i * width).toFixed(2)
-      const end = (min + (i + 1) * width).toFixed(2)
-      return { bin: `${start}-${end}`, count }
-    })
+    return counts
+      .slice(0, maxEntries)
+      .map((count, i) => {
+        const start = (min + i * width).toFixed(2)
+        const end = (min + (i + 1) * width).toFixed(2)
+        return { bin: `${start}-${end}`, count }
+      })
   } catch (e) {
     console.error('Erro ao carregar taxas de retransmissao:', e)
     return []

--- a/src/app/components/charts/retransmissionsChart/RetransmissionsChart.tsx
+++ b/src/app/components/charts/retransmissionsChart/RetransmissionsChart.tsx
@@ -13,10 +13,10 @@ const RetransmissionsChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadRetransmissions(values.url_stats_metricas)
+    loadRetransmissions(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.code.ts
+++ b/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadRetransmissions(url: string): Promise<Array<{ ip: string; count: number }>> {
+export async function loadRetransmissions(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ ip: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.taxa_retransmissoes || {}
-    return Object.entries(map).map(([ip, count]) => ({ ip, count: Number(count) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([ip, count]) => ({ ip, count: Number(count) }))
   } catch (e) {
     console.error('Erro ao carregar retransmissões:', e)
     return []

--- a/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.ts
+++ b/src/app/components/charts/retransmissionsChart/loadRetransmissionsChart.ts
@@ -1,10 +1,15 @@
-export async function loadRetransmissions(url: string): Promise<Array<{ ip: string; count: number }>> {
+export async function loadRetransmissions(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ ip: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.taxa_retransmissoes || {}
-    return Object.entries(map).map(([ip, count]) => ({ ip, count: Number(count) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([ip, count]) => ({ ip, count: Number(count) }))
   } catch (e) {
     console.error('Erro ao carregar retransmissões:', e)
     return []

--- a/src/app/components/charts/rttChart/RttChart.tsx
+++ b/src/app/components/charts/rttChart/RttChart.tsx
@@ -13,10 +13,10 @@ const RttChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadRttPerConnection(values.url_stats_metricas)
+    loadRttPerConnection(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/rttChart/loadRttChart.code.ts
+++ b/src/app/components/charts/rttChart/loadRttChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadRttPerConnection(url: string): Promise<Array<{ id: string; rtt: number }>> {
+export async function loadRttPerConnection(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; rtt: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.rtt_por_conexao || {}
-    return Object.entries(map).map(([id, rtt]) => ({ id, rtt: Number(rtt) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, rtt]) => ({ id, rtt: Number(rtt) }))
   } catch (e) {
     console.error('Erro ao carregar RTT:', e)
     return []

--- a/src/app/components/charts/rttChart/loadRttChart.ts
+++ b/src/app/components/charts/rttChart/loadRttChart.ts
@@ -1,10 +1,15 @@
-export async function loadRttPerConnection(url: string): Promise<Array<{ id: string; rtt: number }>> {
+export async function loadRttPerConnection(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; rtt: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.rtt_por_conexao || {}
-    return Object.entries(map).map(([id, rtt]) => ({ id, rtt: Number(rtt) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, rtt]) => ({ id, rtt: Number(rtt) }))
   } catch (e) {
     console.error('Erro ao carregar RTT:', e)
     return []

--- a/src/app/components/charts/rttScatterChart/RttScatterChart.tsx
+++ b/src/app/components/charts/rttScatterChart/RttScatterChart.tsx
@@ -13,10 +13,10 @@ const RttScatterChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadRttScatter(values.url_stats_metricas)
+    loadRttScatter(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/rttScatterChart/loadRttScatterChart.code.ts
+++ b/src/app/components/charts/rttScatterChart/loadRttScatterChart.code.ts
@@ -1,5 +1,8 @@
 export const code = `
-export async function loadRttScatter(url: string): Promise<Array<{ idx: number; rtt: number }>> {
+export async function loadRttScatter(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ idx: number; rtt: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -8,7 +11,9 @@ export async function loadRttScatter(url: string): Promise<Array<{ idx: number; 
     const values = Array.isArray(map)
       ? map.map(([, r]: [string, number]) => Number(r))
       : Object.values(map).map(Number)
-    return values.map((rtt, i) => ({ idx: i + 1, rtt }))
+    return values
+      .slice(0, maxEntries)
+      .map((rtt, i) => ({ idx: i + 1, rtt }))
   } catch (e) {
     console.error('Erro ao carregar RTT scatter:', e)
     return []

--- a/src/app/components/charts/rttScatterChart/loadRttScatterChart.ts
+++ b/src/app/components/charts/rttScatterChart/loadRttScatterChart.ts
@@ -1,4 +1,7 @@
-export async function loadRttScatter(url: string): Promise<Array<{ idx: number; rtt: number }>> {
+export async function loadRttScatter(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ idx: number; rtt: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -7,7 +10,9 @@ export async function loadRttScatter(url: string): Promise<Array<{ idx: number; 
     const values = Array.isArray(map)
       ? map.map(([, r]: [string, number]) => Number(r))
       : Object.values(map).map(Number)
-    return values.map((rtt, i) => ({ idx: i + 1, rtt }))
+    return values
+      .slice(0, maxEntries)
+      .map((rtt, i) => ({ idx: i + 1, rtt }))
   } catch (e) {
     console.error('Erro ao carregar RTT scatter:', e)
     return []

--- a/src/app/components/charts/segmentSizeChart/SegmentSizeChart.tsx
+++ b/src/app/components/charts/segmentSizeChart/SegmentSizeChart.tsx
@@ -13,10 +13,10 @@ const SegmentSizeChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadSegmentSizeDistribution(values.url_stats_completo)
+    loadSegmentSizeDistribution(values.url_stats_completo, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_completo])
+  }, [values.url_stats_completo, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.code.ts
+++ b/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.code.ts
@@ -1,5 +1,8 @@
 export const code = `
-export async function loadSegmentSizeDistribution(url: string): Promise<Array<{ size: number; count: number }>> {
+export async function loadSegmentSizeDistribution(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ size: number; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -10,7 +13,9 @@ export async function loadSegmentSizeDistribution(url: string): Promise<Array<{ 
       const v = Number(s)
       map[v] = (map[v] || 0) + 1
     }
-    return Object.entries(map).map(([size, count]) => ({ size: Number(size), count }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([size, count]) => ({ size: Number(size), count }))
   } catch (e) {
     console.error('Erro ao carregar distribuição de tamanhos:', e)
     return []

--- a/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.ts
+++ b/src/app/components/charts/segmentSizeChart/loadSegmentSizeChart.ts
@@ -1,4 +1,7 @@
-export async function loadSegmentSizeDistribution(url: string): Promise<Array<{ size: number; count: number }>> {
+export async function loadSegmentSizeDistribution(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ size: number; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
@@ -9,7 +12,9 @@ export async function loadSegmentSizeDistribution(url: string): Promise<Array<{ 
       const v = Number(s)
       map[v] = (map[v] || 0) + 1
     }
-    return Object.entries(map).map(([size, count]) => ({ size: Number(size), count }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([size, count]) => ({ size: Number(size), count }))
   } catch (e) {
     console.error('Erro ao carregar distribuição de tamanhos:', e)
     return []

--- a/src/app/components/charts/throughputChart/ThroughputChart.tsx
+++ b/src/app/components/charts/throughputChart/ThroughputChart.tsx
@@ -13,10 +13,10 @@ const ThroughputChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadThroughput(values.url_stats_metricas)
+    loadThroughput(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/throughputChart/loadThroughputChart.code.ts
+++ b/src/app/components/charts/throughputChart/loadThroughputChart.code.ts
@@ -1,11 +1,16 @@
 export const code = `
-export async function loadThroughput(url: string): Promise<Array<{ id: string; value: number }>> {
+export async function loadThroughput(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; value: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.throughput_por_conexao || {}
-    return Object.entries(map).map(([id, value]) => ({ id, value: Number(value) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, value]) => ({ id, value: Number(value) }))
   } catch (e) {
     console.error('Erro ao carregar throughput:', e)
     return []

--- a/src/app/components/charts/throughputChart/loadThroughputChart.ts
+++ b/src/app/components/charts/throughputChart/loadThroughputChart.ts
@@ -1,10 +1,15 @@
-export async function loadThroughput(url: string): Promise<Array<{ id: string; value: number }>> {
+export async function loadThroughput(
+  url: string,
+  maxEntries = 10000
+): Promise<Array<{ id: string; value: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.throughput_por_conexao || {}
-    return Object.entries(map).map(([id, value]) => ({ id, value: Number(value) }))
+    return Object.entries(map)
+      .slice(0, maxEntries)
+      .map(([id, value]) => ({ id, value: Number(value) }))
   } catch (e) {
     console.error('Erro ao carregar throughput:', e)
     return []

--- a/src/app/components/charts/topApplicationsChart/TopApplicationsChart.tsx
+++ b/src/app/components/charts/topApplicationsChart/TopApplicationsChart.tsx
@@ -13,10 +13,10 @@ const TopApplicationsChart = () => {
 
   useEffect(() => {
     setLoading(true)
-    loadTopApplications(values.url_stats_metricas)
+    loadTopApplications(values.url_stats_metricas, values.maxEntries)
       .then(setData)
       .finally(() => setLoading(false))
-  }, [values.url_stats_metricas])
+  }, [values.url_stats_metricas, values.maxEntries])
 
   if (loading) return <ChartLoad />
 

--- a/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.code.ts
+++ b/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.code.ts
@@ -1,12 +1,17 @@
 export const code = `
-export async function loadTopApplications(url: string): Promise<Array<{ port: string; count: number }>> {
+export async function loadTopApplications(
+  url: string,
+  maxEntries = 10
+): Promise<Array<{ port: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.top_aplicacoes_portas || {}
-    const entries = Object.entries(map).map(([port, count]) => ({ port, count: Number(count) }))
-    return entries.sort((a, b) => b.count - a.count).slice(0, 10)
+    const entries = Object.entries(map)
+      .map(([port, count]) => ({ port, count: Number(count) }))
+      .sort((a, b) => b.count - a.count)
+    return entries.slice(0, maxEntries)
   } catch (e) {
     console.error('Erro ao carregar top aplicações:', e)
     return []

--- a/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.ts
+++ b/src/app/components/charts/topApplicationsChart/loadTopApplicationsChart.ts
@@ -1,11 +1,16 @@
-export async function loadTopApplications(url: string): Promise<Array<{ port: string; count: number }>> {
+export async function loadTopApplications(
+  url: string,
+  maxEntries = 10
+): Promise<Array<{ port: string; count: number }>> {
   try {
     const res = await fetch(url, { cache: 'no-store' })
     if (!res.ok) throw new Error('Erro ao carregar o JSON')
     const data = await res.json()
     const map: Record<string, number> = data.top_aplicacoes_portas || {}
-    const entries = Object.entries(map).map(([port, count]) => ({ port, count: Number(count) }))
-    return entries.sort((a, b) => b.count - a.count).slice(0, 10)
+    const entries = Object.entries(map)
+      .map(([port, count]) => ({ port, count: Number(count) }))
+      .sort((a, b) => b.count - a.count)
+    return entries.slice(0, maxEntries)
   } catch (e) {
     console.error('Erro ao carregar top aplicações:', e)
     return []

--- a/src/app/contexts/MainValuesContext.tsx
+++ b/src/app/contexts/MainValuesContext.tsx
@@ -14,6 +14,7 @@ export interface MainValues {
   maxIPGPoints: number
   maxIPGValue: number
   maxPoints: number
+  maxEntries: number
 }
 
 const defaultValues: MainValues = {
@@ -27,6 +28,7 @@ const defaultValues: MainValues = {
   maxIPGPoints: 10000,
   maxIPGValue: 5,
   maxPoints: 10000,
+  maxEntries: 10000,
 }
 
 const MainValuesContext = createContext<{

--- a/src/app/t2-descricoes/Descriptions.tsx
+++ b/src/app/t2-descricoes/Descriptions.tsx
@@ -42,6 +42,15 @@ export default function DescricoesGerais() {
               onChange={handleChange('url_stats_completo')}
               fullWidth
             />
+            <TextField
+              label="maxEntries"
+              type="number"
+              value={values.maxEntries}
+              onChange={handleChange('maxEntries')}
+            />
+            <h6 style={{ marginTop: 0, fontWeight: 400 }}>
+              Limite máximo de registros a serem carregados por gráfico.
+            </h6>
           </Stack>
         </ChartAccordion>
       </ChartBox>


### PR DESCRIPTION
## Summary
- add `maxEntries` to main values context
- expose new parameter in T2 descriptions
- update T2 charts and loaders to respect `maxEntries`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f9dd24a0832894eea9b5ad9c65ed